### PR TITLE
fix(templates): Keep table headers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -116,7 +116,7 @@
             }
             table = document.getElementById("pull_request_table");
             tr = table.getElementsByTagName("tr");
-            for(i=0; i<tr.length; i++){
+            for(i=1; i<tr.length; i++){
                 if (rowWithMatchingFiles(tr[i], file_array)){
                     tr[i].style.display = "";
                 }


### PR DESCRIPTION
Currently, the table headers vanish after first search. This is because
of wrong starting index in the for loop used in the script.